### PR TITLE
Deduplicate requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "path": "^0.12.7",
     "prop-types": "^15.6.0",
     "react-native-uuid": "^1.4.9",
+    "rxjs": "^6.6.0",
     "traverse": "^0.6.6",
     "url-parse": "^1.2.0",
     "validator": "^13.1.1"

--- a/src/FileSystem.tsx
+++ b/src/FileSystem.tsx
@@ -393,6 +393,16 @@ export class FileSystem {
     }
   }
 
+  /**
+   * Gets a observable which emits when a url is resolved to a local file path
+   * A cache lock is required @see {lockCacheFile}
+   *
+   * @param url {String} - url of file to download.
+   * @param componentId {String} - Unique id of the requestor.
+   * @param permanent {Boolean} - True persists the file locally indefinitely, false caches the file temporarily (until file is removed during cache pruning).
+   * @param fileName {String} - defaults to a sha1 hash of the url param with extension of same filetype.
+   * @returns {Observable<CacheFileInfo>} observable that resolves to an object that contains the local path of the downloaded file and the filename.
+   */
   observable(
     url: string,
     componentId: string,

--- a/tests/FileSystem.test.tsx
+++ b/tests/FileSystem.test.tsx
@@ -3,6 +3,8 @@ import FileSystemFactory, { FileSystem } from '../src/FileSystem'
 import pathLib from 'path'
 import { mockData } from './mockData'
 import RNFS from 'react-native-fs'
+import { doesNotThrow } from 'should'
+import uuid from 'react-native-uuid'
 
 describe('FileSystem', function () {
   // Test static class properties and methods
@@ -63,89 +65,85 @@ describe('FileSystem', function () {
   })
 
   it('#exists mocked as true.', () => {
-    RNFS.exists.mockResolvedValue(true)
-
     const fileSystem = FileSystemFactory()
 
     return expect(fileSystem.exists('abitrary-file.jpg')).resolves.toEqual(true)
   })
 
-  it('#getFileNameFromUrl should create a sha1 filename from a PNG/JPG/GIF/BMP url.', async () => {
+  it('#getFileNameFromUrl should create a sha1 filename from a PNG/JPG/GIF/BMP url.', () => {
     const fileSystem = FileSystemFactory()
 
-    const pngFilename = await fileSystem.getFileNameFromUrl(
+    const pngFilename = fileSystem.getFileNameFromUrl(
       'https://img.wennermedia.com/5333a62d-07db-432a-92e2-198cafa38a14-326adb1a-d8ed-4a5d-b37e-5c88883e1989.png',
     )
 
     pngFilename.should.equal('cd7d2199cd8e088cdfd9c99fc6359666adc36289.png')
 
-    const gifFilename = await fileSystem.getFileNameFromUrl(
+    const gifFilename = fileSystem.getFileNameFromUrl(
       'https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif',
     )
 
     gifFilename.should.equal('c048132247cd28c7879ab36d78a8f45194640006.gif')
 
-    const jpgFilename = await fileSystem.getFileNameFromUrl(
+    const jpgFilename = fileSystem.getFileNameFromUrl(
       'https://cdn2.hubspot.net/hub/42284/file-14233687-jpg/images/test_in_red.jpg',
     )
 
     jpgFilename.should.equal('6adf4569ecc3bf8c378bb4d47b1995cd85c5a13c.jpg')
 
-    const bmpFilename = await fileSystem.getFileNameFromUrl(
+    const bmpFilename = fileSystem.getFileNameFromUrl(
       'https://cdn-learn.adafruit.com/assets/assets/000/010/147/original/tiger.bmp',
     )
 
     bmpFilename.should.equal('282fb62d2caff367aff828ce21e79575733605c8.bmp')
   })
 
-  it('#getFileNameFromUrl should handle urls with same pathname but different query strings or fragments as individual files.', async () => {
+  it('#getFileNameFromUrl should handle urls with same pathname but different query strings or fragments as individual files.', () => {
     const fileSystem = FileSystemFactory()
 
-    const pngFilename = await fileSystem.getFileNameFromUrl(
+    const pngFilename = fileSystem.getFileNameFromUrl(
       'https://img.wennermedia.com/5333a62d-07db-432a-92e2-198cafa38a14-326adb1a-d8ed-4a5d-b37e-5c88883e1989.png?exampleparam=one&anotherparam=2#this-is-a-fragment',
     )
 
     pngFilename.should.equal('9eea25bf871c2333648080180f6b616a91ce1b09.png')
 
-    const pngFilenameTwo = await fileSystem.getFileNameFromUrl(
+    const pngFilenameTwo = fileSystem.getFileNameFromUrl(
       'https://img.wennermedia.com/5333a62d-07db-432a-92e2-198cafa38a14-326adb1a-d8ed-4a5d-b37e-5c88883e1989.png?exampleparam=DIFFERENT&anotherparam=2#this-is-a-fragment-two',
     )
 
     pngFilenameTwo.should.equal('09091b8880ddb982968a0fe28abed5034f9a43b8.png')
   })
 
-  it('#getFileNameFromUrl should handle PNG/JPG/GIF/BMP urls and urls without file extensions.', async () => {
+  it('#getFileNameFromUrl should handle PNG/JPG/GIF/BMP urls and urls without file extensions.', () => {
     const fileSystem = FileSystemFactory()
 
-    const pngFilename = await fileSystem.getFileNameFromUrl(
+    const pngFilename = fileSystem.getFileNameFromUrl(
       'https://cdn2.hubspot.net/hub/42284/file-14233687-jpg/images/test_in_red.png',
     )
     pngFilename.should.equal('b89a6739cdfd993a9b5d43b2ff4aa216e17c63ae.png')
 
-    const jpgFilename = await fileSystem.getFileNameFromUrl(
+    const jpgFilename = fileSystem.getFileNameFromUrl(
       'https://cdn2.hubspot.net/hub/42284/file-14233687-jpg/images/test_in_red.jpg',
     )
     jpgFilename.should.equal('6adf4569ecc3bf8c378bb4d47b1995cd85c5a13c.jpg')
 
-    const gifFilename = await fileSystem.getFileNameFromUrl(
+    const gifFilename = fileSystem.getFileNameFromUrl(
       'https://cdn2.hubspot.net/hub/42284/file-14233687-jpg/images/test_in_red.gif',
     )
     gifFilename.should.equal('f0bc1d93ca75e6e355188391e3d0f1aab6d30bad.gif')
 
-    const bmpFilename = await fileSystem.getFileNameFromUrl(
+    const bmpFilename = fileSystem.getFileNameFromUrl(
       'https://cdn2.hubspot.net/hub/42284/file-14233687-jpg/images/test_in_red.bmp',
     )
     bmpFilename.should.equal('ca15f1856605a6a5ca1d426a12f91efdc061b31c.bmp')
 
-    const unknownFilename = await fileSystem.getFileNameFromUrl(
+    const unknownFilename = fileSystem.getFileNameFromUrl(
       'https://cdn2.hubspot.net/hub/42284/file-14233687-jpg/images/test_in_red',
     )
     unknownFilename.should.equal('831eb245a3d9032cdce450f8760d2b8ddb442a3d.bin')
   })
 
   it('#getLocalFilePathFromUrl should return local filepath if it exists on local fs in permanent dir.', () => {
-    RNFS.exists.mockReturnValue(true).mockReturnValueOnce(true) // mock exist in local permanent dir
-
     const fileSystem = FileSystemFactory()
 
     return fileSystem
@@ -161,10 +159,7 @@ describe('FileSystem', function () {
   })
 
   it('#getLocalFilePathFromUrl should return local filepath if it exists on local fs in cache dir.', () => {
-    RNFS.exists
-      .mockReturnValueOnce(false) // mock not exist in local permanent dir
-      .mockReturnValueOnce(true) // mock exist in local cache dir
-      .mockReturnValue(true)
+    RNFS.exists.mockResolvedValueOnce(false) // mock not exist in local permanent dir
 
     const fileSystem = FileSystemFactory()
 
@@ -182,7 +177,6 @@ describe('FileSystem', function () {
 
   it('#getLocalFilePathFromUrl should download file and write to disk (default to cache dir) if it does not exist on local fs.', () => {
     RNFS.exists
-      .mockResolvedValue(true)
       .mockResolvedValueOnce(false) // mock not exist in local permanent dir
       .mockResolvedValueOnce(false) // mock not exist in local cache dir
       .mockResolvedValueOnce(false) // mock does not exist to get past clobber
@@ -209,20 +203,19 @@ describe('FileSystem', function () {
 
     const badFileName = '../../../../bad-filename.jpg'
 
-    return fileSystem
-      .fetchFile('https://google.com/arbitrary.jpg', true, badFileName)
-      .then(() => {
-        throw new Error('Bad file name was not caught.')
-      })
-      .catch((error) => {
+    expect(() =>
+      fileSystem.fetchFile('https://google.com/arbitrary.jpg', true, badFileName),
+    ).toThrow(
+      (() => {
         const resolvedPath = pathLib.resolve(
           mockData.basePath + '/react-native-image-cache-hoc/permanent/' + badFileName,
         )
-        error.should.deepEqual(new Error(resolvedPath + ' is not a valid file path.'))
-      })
+        return resolvedPath + ' is not a valid file path.'
+      })(),
+    )
   })
 
-  it('#fetchFile clobber safeguard should work.', () => {
+  it('#fetchFile clobber safeguard should work.', (done) => {
     const fileSystem = FileSystemFactory()
 
     RNFS.downloadFile.mockReturnValue({
@@ -230,25 +223,17 @@ describe('FileSystem', function () {
     })
 
     // fileSystem.exists() is mocked to always return true, so error should always be thrown unless clobber is set to true.
-    return fileSystem
+    fileSystem
       .fetchFile(
         'https://img.wennermedia.com/5333a62d-07db-432a-92e2-198cafa38a14-326adb1a-d8ed-4a5d-b37e-5c88883e1989.png',
       )
-      .then(() => {
-        throw new Error('Clobber logic failed, a file was overwritten.')
-      })
-      .catch((error) => {
-        error.should.deepEqual(
-          new Error(
-            'A file already exists at ' +
-              mockData.basePath +
-              '/react-native-image-cache-hoc/cache/cd7d2199cd8e088cdfd9c99fc6359666adc36289.png and clobber is set to false.',
-          ),
-        )
+      .subscribe(({ path }) => {
+        expect(path).toBeNull()
+        done()
       })
   })
 
-  it('#fetchFile prune logic should not be called on permanent writes.', () => {
+  it('#fetchFile prune logic should not be called on permanent writes.', (done) => {
     const fileSystem = FileSystemFactory()
 
     RNFS.downloadFile.mockReturnValue({
@@ -258,24 +243,25 @@ describe('FileSystem', function () {
     let pruneCacheHit = false
 
     // Mock fileSystem.pruneCache() to determine if it is called correctly.
-    fileSystem.pruneCache = () => {
+    fileSystem.pruneCache = async () => {
       pruneCacheHit = true
     }
 
     // fileSystem.exists() is mocked to always return true, so error should always be thrown unless clobber is set to true.
-    return fileSystem
+    fileSystem
       .fetchFile(
         'https://img.wennermedia.com/5333a62d-07db-432a-92e2-198cafa38a14-326adb1a-d8ed-4a5d-b37e-5c88883e1989.png',
         true,
         null,
         true,
       )
-      .then(() => {
+      .subscribe(() => {
         pruneCacheHit.should.be.false()
+        done()
       })
   })
 
-  it('#fetchFile prune logic should be called on cache writes.', () => {
+  it('#fetchFile prune logic should be called on cache writes.', (done) => {
     const fileSystem = FileSystemFactory()
 
     RNFS.downloadFile.mockReturnValue({
@@ -285,24 +271,25 @@ describe('FileSystem', function () {
     let pruneCacheHit = false
 
     // Mock fileSystem.pruneCache() to determine if it is called correctly.
-    fileSystem.pruneCache = () => {
+    fileSystem.pruneCache = async () => {
       pruneCacheHit = true
     }
 
     // fileSystem.exists() is mocked to always return true, so error should always be thrown unless clobber is set to true.
-    return fileSystem
+    fileSystem
       .fetchFile(
         'https://img.wennermedia.com/5333a62d-07db-432a-92e2-198cafa38a14-326adb1a-d8ed-4a5d-b37e-5c88883e1989.png',
         false,
         null,
         true,
       )
-      .then(() => {
+      .subscribe(() => {
         pruneCacheHit.should.be.true()
+        done()
       })
   })
 
-  it('#fetchFile should work as expected.', () => {
+  it('#fetchFile should work as expected.', (done) => {
     const fileSystem = FileSystemFactory()
 
     RNFS.downloadFile.mockReturnValue({
@@ -310,22 +297,23 @@ describe('FileSystem', function () {
     })
 
     // Mock fileSystem.pruneCache().
-    fileSystem.pruneCache = () => {}
+    fileSystem.pruneCache = async () => {}
 
     // fileSystem.exists() is mocked to always return true, so error should always be thrown unless clobber is set to true.
-    return fileSystem
+    fileSystem
       .fetchFile(
         'https://img.wennermedia.com/5333a62d-07db-432a-92e2-198cafa38a14-326adb1a-d8ed-4a5d-b37e-5c88883e1989.png',
         false,
         null,
         true,
       )
-      .then((result) => {
+      .subscribe((result) => {
         result.should.deepEqual({
           path:
             '/base/file/path/react-native-image-cache-hoc/cache/cd7d2199cd8e088cdfd9c99fc6359666adc36289.png',
           fileName: 'cd7d2199cd8e088cdfd9c99fc6359666adc36289.png',
         })
+        done()
       })
   })
 
@@ -354,7 +342,6 @@ describe('FileSystem', function () {
 
   it('#unlink should work as expected for valid paths.', () => {
     // Mock unlink to be true.
-    RNFS.exists.mockResolvedValueOnce(true)
     RNFS.unlink.mockResolvedValueOnce(true)
 
     const fileSystem = FileSystemFactory()
@@ -362,5 +349,70 @@ describe('FileSystem', function () {
     const validPath = '/permanent/valid.jpg'
 
     return expect(fileSystem.unlink(validPath)).resolves.toEqual(true)
+  })
+
+  it('#unlink should work as expected for invalid paths.', () => {
+    // Mock unlink to be false.
+    RNFS.exists.mockResolvedValueOnce(false)
+
+    const fileSystem = FileSystemFactory()
+
+    const validPath = '/permanent/invalid.jpg'
+
+    return expect(fileSystem.unlink(validPath)).resolves.toEqual(true)
+  })
+
+  it('#observable should throw if a lock does not exist', () => {
+    const fileSystem = FileSystemFactory()
+
+    expect(() => fileSystem.observable('https://i.redd.it/rc29s4bz61uz.png', uuid.v4())).toThrow(
+      'A lock must be aquired before requesting an observable',
+    )
+  })
+
+  it('#observable should reuse existing observables', () => {
+    const fileSystem = FileSystemFactory()
+
+    const url = 'https://i.redd.it/rc29s4bz61uz.png'
+    const fileName = fileSystem.getFileNameFromUrl(url)
+    const componentIdA = uuid.v4()
+    const componentIdB = uuid.v4()
+
+    FileSystem.lockCacheFile(fileName, componentIdA)
+    FileSystem.lockCacheFile(fileName, componentIdB)
+
+    const a = fileSystem.observable(url, componentIdA)
+    const b = fileSystem.observable(url, componentIdB)
+
+    expect(a).toBe(b)
+
+    FileSystem.unlockCacheFile(fileName, componentIdA)
+    FileSystem.unlockCacheFile(fileName, componentIdB)
+  })
+
+  it('#observable should handle failure responses on download', (done) => {
+    const fileSystem = FileSystemFactory()
+
+    RNFS.exists
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+
+    RNFS.downloadFile.mockReturnValue({
+      promise: Promise.resolve({ statusCode: 404 }),
+    })
+
+    fileSystem
+      .fetchFile(
+        'https://img.wennermedia.com/5333a62d-07db-432a-92e2-198cafa38a14-326adb1a-d8ed-4a5d-b37e-5c88883e1989.png',
+        false,
+        null,
+        true,
+      )
+      .subscribe(({ path }) => {
+        expect(path).toBeNull()
+
+        done()
+      })
   })
 })

--- a/tests/__mocks__/react-native-fs.tsx
+++ b/tests/__mocks__/react-native-fs.tsx
@@ -9,7 +9,7 @@ module.exports = {
   getFSInfo: jest.fn(),
   getAllExternalFilesDirs: jest.fn(),
   unlink: jest.fn(),
-  exists: jest.fn(),
+  exists: jest.fn().mockResolvedValue(true),
   stopDownload: jest.fn(),
   resumeDownload: jest.fn(),
   isResumable: jest.fn(),

--- a/tests/imageCacheHoc.test.tsx
+++ b/tests/imageCacheHoc.test.tsx
@@ -13,7 +13,6 @@ describe('CacheableImage', function () {
       .mockResolvedValueOnce(false) // mock not exist in local permanent dir
       .mockResolvedValueOnce(false) // mock not exist in local cache dir
       .mockResolvedValueOnce(false) // mock does not exist to get past clobber
-      .mockResolvedValue(true)
 
     RNFS.downloadFile.mockReturnValue({
       promise: Promise.resolve({ statusCode: 200 }),
@@ -51,7 +50,6 @@ describe('CacheableImage', function () {
       .mockResolvedValueOnce(false) // mock not exist in local permanent dir
       .mockResolvedValueOnce(false) // mock not exist in local cache dir
       .mockResolvedValueOnce(false) // mock does not exist to get past clobber
-      .mockResolvedValue(true)
 
     RNFS.downloadFile.mockReturnValue({
       promise: Promise.resolve({ statusCode: 200 }),
@@ -96,7 +94,6 @@ describe('CacheableImage', function () {
       .mockResolvedValueOnce(false) // mock not exist in local permanent dir
       .mockResolvedValueOnce(false) // mock not exist in local cache dir
       .mockResolvedValueOnce(false) // mock does not exist to get past clobber
-      .mockResolvedValue(true)
 
     RNFS.downloadFile.mockReturnValue({
       promise: Promise.resolve({ statusCode: 200 }),


### PR DESCRIPTION
Uses RxJS to deduplicate requests, errors are caught and `{ path: null }` returned.
I expect it's possible to improve the `fetchFile` logic, perhaps merging some of the operators.
Most of the lifecycle methods have async removed from the hoc.